### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css linguist-language=Javascript


### PR DESCRIPTION
This files enables github to index or recognize Javascript as your core repository language instead of CSS.