### PR TITLE
add .gitattributes to index Javascript.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css linguist-language=Javascript


### PR DESCRIPTION
The ,gitattributes is a file that allows GitHub recognize your repository as JavaScript instead of CSS. This doesn't affect the application itself or the git repository in anyway.
It is just for proper language recognition .